### PR TITLE
Using docker for building (and running) the native image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM danny02/graalvm as native-image-builder
+COPY target/micro*.jar /app.jar
+COPY graal.json /graal.json
+RUN native-image -Dio.netty.noUnsafe=true -H:Name=micro -H:ReflectionConfigurationFiles=graal.json --report-unsupported-elements-at-runtime \
+  -cp $(java -jar /app.jar --thin.classpath --thin.profile=graal) com.example.micro.MicroApplication
+
+FROM ubuntu:18.04
+COPY --from=native-image-builder /micro /micro
+EXPOSE 8080
+ENTRYPOINT [ "/micro" ]

--- a/README.adoc
+++ b/README.adoc
@@ -70,3 +70,29 @@ Started HttpServer: 2ms
 ```
 
 Excellent!
+
+=== Docker support
+
+In case you are using https://www.docker.com/[Docker], you can use the provided link:Dockerfile[]
+for building the native image, so you would not have to setup https://github.com/oracle/graal/releases[GraalVM]
+on your machine.
+
+
+```
+$ docker build -t io.spring.example/functional-spring-native-image .
+```
+
+Afterwards, you can run the created Docker-image `io.spring.example/functional-spring-native-image`
+
+```
+$ docker run -p8080:8080 io.spring.example/functional-spring-native-image
+Started HttpServer: 3ms
+
+$ docker ps
+CONTAINER ID  IMAGE                                              COMMAND    PORTS
+61f0ee217d6e  io.spring.example/functional-spring-native-image   "/micro"   0.0.0.0:8080->8080/tcp
+
+$ docker stats 61f0ee217d6e
+CONTAINER ID  CPU %   MEM USAGE
+61f0ee217d6e  0.04%   42.91MiB
+```

--- a/src/main/java/com/example/config/ApplicationBuilder.java
+++ b/src/main/java/com/example/config/ApplicationBuilder.java
@@ -57,7 +57,7 @@ public class ApplicationBuilder {
 
 		HttpHandler handler = WebHttpHandlerBuilder.applicationContext(context).build();
 		ReactorHttpHandlerAdapter adapter = new ReactorHttpHandlerAdapter(handler);
-		HttpServer httpServer = HttpServer.create("localhost",
+		HttpServer httpServer = HttpServer.create(
 				context.getEnvironment().getProperty("server.port", Integer.class, 8080));
 		httpServer.startAndAwait(adapter, callback(callback));
 	}


### PR DESCRIPTION
I created Docker support this application, using https://hub.docker.com/r/danny02/graalvm/ for automated building of the native image.

Note: I tried to https://hub.docker.com/_/scratch/ as base image (using native-image `--static`), but the created failed with a SegFault when being run.